### PR TITLE
Minimap2 rs changes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,9 +70,15 @@ sprs = "0.11.2"
 
 # alternative sources for dev
 #minimap2-temp = { version = "0.1.20", git = "https://github.com/rob-p/minimap2-rs.git", branch = "alignment-score" }
-minimap2-sys = { version = "0.1.19+minimap2.2.28", git = "https://github.com/rob-p/minimap2-sys", branch = "main" }
-minimap2 = { version = "0.1.21+minimap2.2.28", git = "https://github.com/rob-p/minimap2-rs", branch = "main" }
+# minimap2-sys = { version = "0.1.19+minimap2.2.28", git = "https://github.com/rob-p/minimap2-sys", branch = "main" }
+# minimap2 = { version = "0.1.21+minimap2.2.28", git = "https://github.com/rob-p/minimap2-rs", branch = "main" }
 #minimap2 = { version = "0.1.20", git = "https://github.com/jguhlin/minimap2-rs.git", branch = "alignment-score" }
+minimap2-sys = { version = "0.1.20+minimap2.2.28", git = "https://github.com/jguhlin/minimap2-rs", branch = "Aligner-clone-logistics" }
+minimap2 = { version = "0.1.21+minimap2.2.28", git = "https://github.com/jguhlin/minimap2-rs", branch = "Aligner-clone-logistics" }
+
+# Or now minimap2-sys is exported in minimap2:
+# use minimap2_sys::ffi as mm_ffi;
+
 
 needletail = "0.6.0"
 indicatif = "0.17.9"

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,8 @@ use anyhow::Context;
 
 use core::ffi;
 use minimap2_sys as mm_ffi;
+// Or now
+// use minimap2_sys::ffi as mm_ffi;
 //use minimap2_temp as minimap2;
 use num_format::{Locale, ToFormattedString};
 use std::{fs::File, io};
@@ -124,8 +126,7 @@ fn get_aligner_from_args(args: &Args) -> anyhow::Result<HeaderReaderAligner> {
     for i in 0..n_seq {
         let _seq = unsafe { *(**mmi).seq.offset(i as isize) };
         // Or now:
-        // let _seq = aligner.get_seq(i as usize).unwrap()
-        // -- should work, not tested!
+        // let _seq = aligner.get_seq(i as usize).unwrap();
         let c_str = unsafe { ffi::CStr::from_ptr(_seq.name) };
         let rust_str = c_str.to_str().unwrap().to_string();
         header = header.add_reference_sequence(

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,7 @@ use anyhow::Context;
 use core::ffi;
 use minimap2_sys as mm_ffi;
 // Or now
-// use minimap2_sys::ffi as mm_ffi;
+// use minimap2::ffi as mm_ffi;
 //use minimap2_temp as minimap2;
 use num_format::{Locale, ToFormattedString};
 use std::{fs::File, io};

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ use minimap2_sys as mm_ffi;
 //use minimap2_temp as minimap2;
 use num_format::{Locale, ToFormattedString};
 use std::{fs::File, io};
+use std::sync::Arc;
 
 use tracing::info;
 use tracing_subscriber::{filter::LevelFilter, fmt, prelude::*, EnvFilter};
@@ -100,8 +101,10 @@ fn get_aligner_from_args(args: &Args) -> anyhow::Result<HeaderReaderAligner> {
     // minimap2 uses.
     aligner.mapopt.seed = 11;
 
-    let mmi: mm_ffi::mm_idx_t = unsafe { **aligner.idx.as_ref().unwrap() };
-    let n_seq = mmi.n_seq;
+    let mmi: Arc<*mut mm_ffi::mm_idx_t> = Arc::clone(&aligner.idx.as_ref().unwrap());
+    let n_seq = unsafe { (**mmi).n_seq };
+    // Or now:
+    // let n_seq = aligner.n_seq();
 
     info!(
         "index contains {} sequences",
@@ -118,8 +121,11 @@ fn get_aligner_from_args(args: &Args) -> anyhow::Result<HeaderReaderAligner> {
     }
 
     // TODO: better creation of the header
-    for i in 0..mmi.n_seq {
-        let _seq = unsafe { *(mmi.seq).offset(i as isize) };
+    for i in 0..n_seq {
+        let _seq = unsafe { *(**mmi).seq.offset(i as isize) };
+        // Or now:
+        // let _seq = aligner.get_seq(i as usize).unwrap()
+        // -- should work, not tested!
         let c_str = unsafe { ffi::CStr::from_ptr(_seq.name) };
         let rust_str = c_str.to_str().unwrap().to_string();
         header = header.add_reference_sequence(


### PR DESCRIPTION
Was curious where you needed minimap2_sys directly, got carried away.

Also, these lines
```toml
minimap2-sys = { version = "0.1.20+minimap2.2.28", git = "https://github.com/jguhlin/minimap2-rs", branch = "Aligner-clone-logistics" }
minimap2 = { version = "0.1.21+minimap2.2.28", git = "https://github.com/jguhlin/minimap2-rs", branch = "Aligner-clone-logistics" }
```

Let Cargo pull both crates from the same repo. Or at least it's working for me? Cargo is supposed to search workspaces to find them all, so it should work.

Decided to export minimap2-sys from the main crate as ::ffi so you can drop that (optional, ofc).

Also added these two fn's for Aligner

```rust
    /// Get the number of sequences in the index
    pub fn n_seq(&self) -> u32 {
        unsafe {
            let idx = Arc::as_ptr(self.idx.as_ref().unwrap());
            let idx: *const mm_idx_t = *idx;
            (*idx).n_seq as u32
        }
    }

    /// Get sequences direct from the index
    pub fn get_seq<'aln>(&'aln self, i: usize) -> Option<&'aln mm_idx_seq_t> {
        unsafe {
            let idx = Arc::as_ptr(self.idx.as_ref().unwrap());
            let idx: *const mm_idx_t = *idx;
            // todo, should this be > or >=
            if i > self.n_seq() as usize {
                return None;
            }
            let seq = (*idx).seq;
            let seq = seq.offset(i as isize);
            let seq = &*seq;
            Some(seq)
        }
    }
```

So you can call those directly. I didn't make that change in your code, to show how it works with Arc, and kind of test the latest changes in a real environment. Happy to add any ergonomic functions though so you don't have to use -sys directly (at least not often)