### PR TITLE
extend pg check to bramble. support list of known mappers

### DIFF
--- a/src/alignment_parser.rs
+++ b/src/alignment_parser.rs
@@ -9,6 +9,8 @@ use std::path::Path;
 use swapvec::SwapVec;
 use tracing::{error, info};
 
+const KNOWN_MAPPERS: [&str; 2] = ["minimap2", "bramble"];
+
 pub fn read_and_verify_header<R: io::BufRead>(
     reader: &mut bam::io::Reader<R>,
     aln_file: &Path,
@@ -52,24 +54,28 @@ pub fn read_and_verify_header<R: io::BufRead>(
         );
     }
 
-    let mut saw_minimap2 = false;
+    let mut matched_prog = None;
     let mut progs = vec![];
     // explicitly check that alignment was done with a supported
-    // aligner (right now, just minimap2).
+    // aligner (right now, minimap2 and bramble).
     for (prog, _pmap) in header.programs().roots() {
-        if prog == "minimap2" {
-            saw_minimap2 = true;
+        if KNOWN_MAPPERS.iter().any(|known| prog == *known) {
+            matched_prog = Some(prog);
             break;
         } else {
             progs.push(prog);
         }
     }
     assert!(
-        saw_minimap2,
-        "Currently, only minimap2 is supported as an aligner. The bam file listed {:?}.",
+        matched_prog.is_some(),
+        "Currently supported aligners are [{}]. The bam file listed {:?}.",
+        KNOWN_MAPPERS.join(", "),
         progs
     );
-    info!("saw minimap2 as a program in the header; proceeding.");
+    info!(
+        "saw supported mapper {} as a program in the header; proceeding.",
+        matched_prog.unwrap()
+    );
     Ok(header)
 }
 


### PR DESCRIPTION
Propose extending support to multiple tools. Known mappers defined in a module-specific const array and checked against when parsing pg lines. Adding bramble to the list of supported tools.