### PR TITLE
ci(sanitize): refuse to move an existing release tag

### DIFF
--- a/.github/workflows/sanitize-cargo.yml
+++ b/.github/workflows/sanitize-cargo.yml
@@ -29,10 +29,21 @@ jobs:
       - name: Tag and push new commit
         run: |
           export VERSION_TAG=`cargo read-manifest | jq ".version" | tr -d '"'`
+          # Never move an existing release tag. A force-push of main (or any
+          # re-push whose head commit still carries [do_tag]) re-triggers this
+          # workflow on an already-released version; force-tagging there would
+          # silently repoint the tag at a fresh commit and change the checksum
+          # of GitHub's generated source tarball for downstream packagers
+          # (see issue #73). Re-releasing a version now requires deleting the
+          # tag by hand first.
+          if git ls-remote --exit-code --tags origin "refs/tags/v${VERSION_TAG}" >/dev/null 2>&1; then
+            echo "::error::tag v${VERSION_TAG} already exists on origin; refusing to move it. Bump the version, or delete the tag manually to re-release."
+            exit 1
+          fi
           git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
           git add Cargo.toml.cs_orig
           git add Cargo.toml
           git commit -m "create sanitized release"
-          git tag --force -a v${VERSION_TAG} -m "version ${VERSION_TAG}"
-          git push --force origin v${VERSION_TAG}
+          git tag -a v${VERSION_TAG} -m "version ${VERSION_TAG}"
+          git push origin v${VERSION_TAG}


### PR DESCRIPTION
Fixes the mechanism behind #73.

## What happened

`sanitize-cargo.yml` runs on any push to `main` whose head commit message contains the tag marker, and tagged with `git tag --force` + `git push --force`. On 2026-07-20 `main` was reset back to `3dec905` after an accidental push of dev work; that force-push replayed a push event whose head commit was the already-released `v0.10.3` commit, so the job ran a second time on the same source SHA and repointed the tag:

| | before | after |
|---|---|---|
| tag commit | `2a640e25` (Jul 16 12:35:23Z) | `a2e296fb` (Jul 20 03:43:41Z) |
| tree | `b84e6524` | `b84e6524` (identical) |
| parent | `3dec9058` | `3dec9058` (identical) |

The release contents never changed — identical tree SHA — but GitHub stamps archive member mtimes from the commit date, so the generated `v0.10.3.tar.gz` changed bytes and its sha256 went from `4fb1d812…` to `e952fae1…`, breaking checksum verification downstream (Homebrew).

Release assets and crates.io were unaffected: the re-run Release workflow failed at `host` (release already exists) and `Publish to crates.io` was skipped.

## The change

Query `origin` for the tag before doing anything and fail with a clear `::error::` if it already exists, then tag and push without `--force`.

Trade-off: legitimately re-cutting a version now requires deleting the tag by hand first. That is the intent — moving a published tag should be a deliberate, human action, not a side effect of a force-push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)